### PR TITLE
Drop support for 3.10. Add 3.15.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,13 +61,14 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13
             3.13t
             3.14
             3.14t
+            3.15
+            3.15t
             pypy3.11
           allow-prereleases: true
 
@@ -104,20 +105,21 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13
             3.13t
             3.14
             3.14t
+            3.15
+            3.15t
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
           manylinux: auto
       - name: Upload wheels
@@ -147,20 +149,21 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13
             3.13t
             3.14
             3.14t
+            3.15
+            3.15t
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
           manylinux: musllinux_1_2
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
@@ -187,11 +190,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13
             3.14
+            3.15
             ${{ matrix.target == 'x64' && 'pypy3.11' || '' }}
           allow-prereleases: true
           architecture: ${{ matrix.target }}
@@ -199,7 +202,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13 3.14'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.14 3.15'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -251,6 +254,13 @@ jobs:
           python-version: 3.14
           allow-prereleases: true
           architecture: arm64
+      - name: Set up Python 3.15
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        id: cp315
+        with:
+          python-version: 3.15
+          allow-prereleases: true
+          architecture: arm64
       # rust toolchain is not currently installed on windopws arm64 images: https://github.com/actions/partner-runner-images/issues/77
       - name: Setup rust
         id: setup-rust
@@ -262,7 +272,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter ${{ steps.cp311.outputs.python-path }} ${{ steps.cp312.outputs.python-path }} ${{ steps.cp313.outputs.python-path }} ${{ steps.cp314.outputs.python-path }}
+          args: --release --out dist --interpreter ${{ steps.cp311.outputs.python-path }} ${{ steps.cp312.outputs.python-path }} ${{ steps.cp313.outputs.python-path }} ${{ steps.cp314.outputs.python-path }} ${{ steps.cp315.outputs.python-path }}
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -292,13 +302,14 @@ jobs:
           python-version: |
             3.13t
             3.14t
+            3.15t
           allow-prereleases: true
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.13t 3.14t'
+          args: --release --out dist --interpreter '3.13t 3.14t 3.15t'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -324,20 +335,21 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.10
             3.11
             3.12
             3.13
             3.13t
             3.14
             3.14t
+            3.15
+            3.15t
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,18 +34,18 @@ jobs:
       - id: noxenvs-matrix
         run: |
           echo >>$GITHUB_OUTPUT noxenvs=$(
-            uvx nox --list-sessions --json | jq '[.[].session]'
+            uvx nox --list-sessions --json | jq '[.[] | {session, python}]'
           )
 
   test:
-    name: Run ${{ matrix.noxenv }}
+    name: Run ${{ matrix.session }}
     needs: list
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        noxenv: ${{ fromJson(needs.list.outputs.noxenvs) }}
+        include: ${{ fromJson(needs.list.outputs.noxenvs) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,30 +53,21 @@ jobs:
           persist-credentials: false
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libenchant-2-dev
-        if: runner.os == 'Linux' && startsWith(matrix.noxenv, 'docs')
+        if: runner.os == 'Linux' && startsWith(matrix.session, 'docs')
       - name: Install dependencies
         run: brew install enchant
-        if: runner.os == 'macOS' && startsWith(matrix.noxenv, 'docs')
+        if: runner.os == 'macOS' && startsWith(matrix.session, 'docs')
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: |
-            3.11
-            3.12
-            3.13
-            3.13t
-            3.14
-            3.14t
-            3.15
-            3.15t
-            pypy3.11
+          python-version: ${{ matrix.python }}
           allow-prereleases: true
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Run nox
-        run: uvx nox -s "${{ matrix.noxenv }}" -- ${{ matrix.posargs }} # zizmor: ignore[template-injection]
+        run: uvx nox -s "${{ matrix.session }}" # zizmor: ignore[template-injection]
 
   manylinux:
     name: Build manylinux wheels (${{ matrix.target }})

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.14"
     rust: "1.70"
 
 sphinx:

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ PYPROJECT = ROOT / "pyproject.toml"
 DOCS = ROOT / "docs"
 TESTS = ROOT / "tests"
 
-SUPPORTED = ["3.10", "pypy3.11", "3.11", "3.12", "3.13", "3.14"]
+SUPPORTED = ["pypy3.11", "3.11", "3.12", "3.13", "3.14", "3.15"]
 LATEST = SUPPORTED[-1]
 
 nox.options.default_venv_backend = "uv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "url-py"
 description = "Python bindings to Rust's url crate (from Servo)"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 readme = "README.rst"
 keywords = ["data structures", "rust", "persistent"]
 authors = [
@@ -17,11 +17,11 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Rust",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/release.toml
+++ b/release.toml
@@ -4,3 +4,4 @@
 # pushed. cargo-release exists here only to keep Cargo.toml, Cargo.lock, and
 # the git tag in lockstep.
 publish = false
+pre-release-commit-message = "Release {{crate_name}} version {{version}}"


### PR DESCRIPTION
- Drop Python 3.10 from `requires-python`, classifiers, nox sessions, and the CI build matrix.
- Add CPython 3.15 + free-threaded 3.15t across the same matrix.
- Bump Read the Docs to Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)