### PR TITLE
Reserve Mach-O header padding on macOS so install_name_tool can relocate

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // macOS 15 runners use Apple's new linker (ld_prime), which reserves
+    // far less Mach-O header padding than the old ld. Tools like Homebrew
+    // run install_name_tool on installed dylibs, which needs spare header
+    // space; without this flag the relink fails with "updated load commands
+    // do not fit in the header". See pyca/cryptography#14777, which fixed
+    // the same regression there.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
+}


### PR DESCRIPTION
- Apple's new linker (ld_prime), used on macOS 15 runners (which `macos-latest` now resolves to), reserves far less Mach-O header padding than the old `ld`.
- Without spare header space, tools that rewrite a dylib's install name post-install (Homebrew, conda-forge relocation, py2app, etc.) fail with *"updated load commands do not fit in the header"*.
- This `build.rs` passes `-Wl,-headerpad_max_install_names` only on macOS, so the wheels' `.so` ships with enough headerpad to be rewritten downstream.

Mirrors [pyca/cryptography#14777](https://github.com/pyca/cryptography/pull/14777), which fixed the same regression there after their CI moved from `macos-13` to `macos-15` runners. crate-py/rpds@c53484a applied the same fix in the sibling project — there a real bug report (crate-py/rpds#200) confirmed the breakage under Homebrew. `url-py` wasn't bug-reported, but is built with the same toolchain (PyO3 0.28, maturin-action, `macos-latest`) and reproduces the same broken state.