### PR TITLE
Modernize packaging: drop 3.13t wheels, SPDX license, bump Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,6 @@ jobs:
             3.11
             3.12
             3.13
-            3.13t
             3.14
             3.14t
             3.15
@@ -110,7 +109,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
           manylinux: auto
       - name: Upload wheels
@@ -143,7 +142,6 @@ jobs:
             3.11
             3.12
             3.13
-            3.13t
             3.14
             3.14t
             3.15
@@ -154,7 +152,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11'
           manylinux: musllinux_1_2
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
@@ -291,7 +289,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
-            3.13t
             3.14t
             3.15t
           allow-prereleases: true
@@ -300,7 +297,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.13t 3.14t 3.15t'
+          args: --release --out dist --interpreter '3.14t 3.15t'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -329,7 +326,6 @@ jobs:
             3.11
             3.12
             3.13
-            3.13t
             3.14
             3.14t
             3.15
@@ -340,7 +336,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.11 3.12 3.13 3.13t 3.14 3.14t 3.15 3.15t pypy3.11'
+          args: --release --out dist --interpreter '3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
     outputs:
       noxenvs: ${{ steps.noxenvs-matrix.outputs.noxenvs }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - id: noxenvs-matrix
@@ -48,7 +48,7 @@ jobs:
         include: ${{ fromJson(needs.list.outputs.noxenvs) }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
       - name: Run nox
@@ -89,7 +89,7 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python
@@ -132,7 +132,7 @@ jobs:
           - x86_64-unknown-linux-musl
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python
@@ -172,7 +172,7 @@ jobs:
         target: [x64, x86] # x86 is not supported by pypy
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python
@@ -211,7 +211,7 @@ jobs:
           - aarch64-pc-windows-msvc
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       # Install each python version seperatly so that the paths can be passed to maturin. (otherwise finds pre-installed x64 versions)
@@ -282,7 +282,7 @@ jobs:
         target: [x64, x86] # x86 is not supported by pypy
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python
@@ -316,7 +316,7 @@ jobs:
         target: [x86_64, aarch64]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python
@@ -349,7 +349,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,11 +24,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: pedantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ name = "url-py"
 description = "Python bindings to Rust's url crate (from Servo)"
 requires-python = ">=3.11"
 readme = "README.rst"
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["data structures", "rust", "persistent"]
 authors = [
   { name = "Julian Berman", email = "Julian+url-py@GrayVines.com" },
@@ -14,7 +16,6 @@ authors = [
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Rust",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- **Wheels:** drop the experimental free-threaded **3.13t** build from
  every wheel job (3.14t/3.15t remain). 3.15/3.15t and the 3.15
  classifier were already present.
- **License metadata:** replace the legacy
  `License :: OSI Approved :: MIT License` classifier with PEP 639
  `license = "MIT"` + `license-files = ["LICENSE"]`, matching rpds and
  regress.
- **Actions:** bump pinned actions to latest — `actions/checkout`
  v6.0.2 → v7.0.0, `astral-sh/setup-uv` v8.1.0 → v8.2.0,
  `zizmorcore/zizmor-action` v0.5.6 → v0.5.7. (setup-python,
  upload/download-artifact, maturin-action, pypi-publish were already
  latest.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)